### PR TITLE
Reformated code to pass fmt and clippy checks

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use clap::{arg, crate_version, Command};
 
-/// Create the [command](clap::Command) object which will handle all of the command line arguments. 
+/// Create the [command](clap::Command) object which will handle all of the command line arguments.
 pub fn make_cli() -> Command {
     Command::new("tockloader")
         .about("This is a sample description.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
             let adr = sub_matches
                 .get_one::<String>("app-address")
                 .unwrap_or(&default_adr);
-            println!("{}", format!("With App Address {adr}"));
+            println!("With App Address {adr}");
         }
         // If only the "--debug" flag is set, then this branch is executed
         // Or, more likely at this stage, a subcommand hasn't been implemented yet.


### PR DESCRIPTION
This Pull Request fixes issue #14 

I've fixed all clippy warnings, and ran cargo fmt.
Of note is the fact that "cli.rs" was using the wrong line endings.